### PR TITLE
Fix websocket related errors

### DIFF
--- a/components/utils/Authentication.jsx
+++ b/components/utils/Authentication.jsx
@@ -1,4 +1,3 @@
-import WebSocket from 'ws';
 import Socket from '../../socket.js';
 
 const SERVER_DOMAIN = 'ws://localhost:4000';

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
   },
   "homepage": "https://github.com/joaodias/hugito-frontend#readme",
   "devDependencies": {
+    "babel-preset-es2015": "^6.13.2",
+    "babel-preset-react": "^6.11.1",
+    "babel-preset-stage-2": "^6.13.0",
     "babel-cli": "^6.14.0",
     "babel-jest": "^14.1.0",
     "babel-loader": "^5.3.3",
-    "babel-preset-es2015": "^6.14.0",
-    "babel-preset-stage-2": "^6.13.0",
     "babel-register": "^6.14.0",
     "jasmine": "^2.4.1",
     "material-ui": "^0.15.2",
@@ -35,8 +36,6 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "babel-preset-es2015": "^6.13.2",
-    "babel-preset-react": "^6.11.1",
     "bootstrap-social": "^5.0.0",
     "css-loader": "^0.23.1",
     "import": "0.0.6",
@@ -61,15 +60,7 @@
     "redux-auth": "0.0.5-beta5",
     "style-loader": "^0.13.1",
     "validator": "^5.5.0",
-    "webpack-env": "^0.8.0",
-    "ws": "^1.1.1"
-  },
-  "babel": {
-    "presets": [
-      "react",
-      "es2015",
-      "stage-2"
-    ]
+    "webpack-env": "^0.8.0"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",

--- a/spec/authentication.spec.js
+++ b/spec/authentication.spec.js
@@ -1,15 +1,11 @@
 jest.disableAutomock();
-jest.mock('ws');
-
-import WebSocket from 'ws';
 
 import Authentication from '../components/utils/Authentication.jsx';
-
-Authentication.prototype.setCode = jest.fn();
 
 describe("Authentication", () => {
 
     let auth;
+    Authentication.prototype._setupWebSocket = jest.fn();
 
     beforeEach(() => {
         auth = new Authentication();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
         filename: 'bundle.js'
     },
     module: {
+        noParse: ['fs'],
         loaders: [
             {
                 test: /\.jsx?$/,
@@ -24,4 +25,5 @@ module.exports = {
             }
         ]
     }
+    externals: ['ws']
 }


### PR DESCRIPTION
The websocket library was removed and now the function using websockets is being mocked in tests, so ther eis no need for a library at the moment.

Closes #41
